### PR TITLE
Update to new crate naming rules

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-extern crate "pkg-config" as pkg_config;
+extern crate pkg_config;
 
 use pkg_config::Config;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#![crate_name = "glib-2_0-sys"]
+#![crate_name = "glib_2_0_sys"]
 #![crate_type = "lib"]
 
 #![allow(missing_copy_implementations)]


### PR DESCRIPTION
Hyphens are now disallowed in crate names
