### PR TITLE
Use crates.io libc instead of unstable bundled libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,8 @@ repository = "https://github.com/gi-rust/glib-sys.git"
 build = "build.rs"
 links = "glib-2.0"
 
+[dependencies]
+libc = "0.1.5"
+
 [build-dependencies]
 pkg-config = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,6 @@
 #![crate_type = "lib"]
 
 #![allow(missing_copy_implementations)]
-#![allow(unstable_features)]
-
-#![feature(libc)]
 
 extern crate libc;
 


### PR DESCRIPTION
This allows building on stable/beta channels.
